### PR TITLE
Use useradd instead of adduser

### DIFF
--- a/lima-init.sh
+++ b/lima-init.sh
@@ -18,7 +18,7 @@ hostname "${LIMA_CIDATA_HOSTNAME}"
 
 # Create user
 LIMA_CIDATA_HOMEDIR="/home/${LIMA_CIDATA_USER}.linux"
-adduser -h "${LIMA_CIDATA_HOMEDIR}" -u "${LIMA_CIDATA_UID}" -D "${LIMA_CIDATA_USER}"
+useradd --home-dir "${LIMA_CIDATA_HOMEDIR}" --create-home --uid "${LIMA_CIDATA_UID}" "${LIMA_CIDATA_USER}"
 
 # Add user to sudoers
 echo "${LIMA_CIDATA_USER} ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/90-lima-users


### PR DESCRIPTION
`adduser` limits uid to `0..256000`, which is not large enough to map all valid macOS UIDs.

`adduser` sets the gid to the same value as uid; `useradd` seems to create gids starting at `1000`. Lima doesn't care about the GID.
