### PR TITLE
Strip quotes from authorized keys YAML lines

### DIFF
--- a/lima-init.sh
+++ b/lima-init.sh
@@ -26,7 +26,7 @@ echo "${LIMA_CIDATA_USER} ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/90-lima-users
 # Create authorized_keys
 LIMA_CIDATA_SSHDIR="${LIMA_CIDATA_HOMEDIR}"/.ssh
 mkdir -p -m 700 "${LIMA_CIDATA_SSHDIR}"
-awk '/ssh-authorized-keys/ {flag=1; next} /^ *$/ {flag=0} flag {sub(/^ +- /, ""); print $0}' \
+awk '/ssh-authorized-keys/ {flag=1; next} /^ *$/ {flag=0} flag {sub(/^ +- /, ""); gsub("\"", ""); print $0}' \
 	"${LIMA_CIDATA_MNT}"/user-data >"${LIMA_CIDATA_SSHDIR}"/authorized_keys
 LIMA_CIDATA_GID=$(id -g "${LIMA_CIDATA_USER}")
 chown -R "${LIMA_CIDATA_UID}:${LIMA_CIDATA_GID}" "${LIMA_CIDATA_SSHDIR}"


### PR DESCRIPTION
https://github.com/lima-vm/lima/pull/219 adds quotes around the keys, which must be stripped before the keys get written to `~/.ssh/authorized_keys`.
