### PR TITLE
Split lima-init into lima-init-local and lima-init

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,7 @@ docker run -it --rm \
        -v "${PWD}/genapkovl-lima.sh:/home/build/aports/scripts/genapkovl-lima.sh:ro" \
        -v "${PWD}/lima-init.sh:/home/build/lima-init.sh:ro" \
        -v "${PWD}/lima-init.openrc:/home/build/lima-init.openrc:ro" \
+       -v "${PWD}/lima-init-local.openrc:/home/build/lima-init-local.openrc:ro" \
        -v "${PWD}/lima-network.awk:/home/build/lima-network.awk:ro" \
        -v "${PWD}/nerdctl-${NERDCTL_VERSION}:/home/build/nerdctl.tar.gz:ro" \
        $(env | grep ^LIMA_ | xargs -n 1 printf -- '-e %s ') \

--- a/genapkovl-lima.sh
+++ b/genapkovl-lima.sh
@@ -75,9 +75,11 @@ rc_add sshd default
 
 if [ "${LIMA_INSTALL_LIMA_INIT}" == "true" ]; then
     rc_add lima-init default
+    rc_add lima-init-local default
 
     mkdir -p "${tmp}/etc/init.d/"
     cp /home/build/lima-init.openrc "${tmp}/etc/init.d/lima-init"
+    cp /home/build/lima-init-local.openrc "${tmp}/etc/init.d/lima-init-local"
 
     mkdir -p "${tmp}/usr/bin/"
     cp /home/build/lima-init.sh "${tmp}/usr/bin/lima-init"

--- a/lima-init-local.openrc
+++ b/lima-init-local.openrc
@@ -1,0 +1,12 @@
+#!/sbin/openrc-run
+
+depend() {
+  after localmount
+  before net
+  provide lima-init-local
+}
+
+start() {
+  lima-init --local
+  eend 0
+}

--- a/lima-init.openrc
+++ b/lima-init.openrc
@@ -1,8 +1,8 @@
 #!/sbin/openrc-run
 
 depend() {
-  after localmount
-  before net
+  after lima-init-local
+  after net
   provide lima-init
 }
 

--- a/lima-init.sh
+++ b/lima-init.sh
@@ -1,14 +1,18 @@
 #!/bin/sh
-exec >/var/log/lima-init.log 2>&1
+exec >>/var/log/lima-init.log 2>&1
 set -eux
+
+export LIMA_CIDATA_MNT="/mnt/lima-cidata"
+
+if [ "${1:-}" != "--local" ]; then
+    exec "${LIMA_CIDATA_MNT}"/boot.sh
+fi
 
 ln -s /var/log/lima-init.log /var/log/cloud-init-output.log
 
-LIMA_CIDATA_MNT="/mnt/lima-cidata"
 LIMA_CIDATA_DEV="/dev/disk/by-label/cidata"
 mkdir -p -m 700 "${LIMA_CIDATA_MNT}"
 mount -o ro,mode=0700,dmode=0700,overriderockperm,exec,uid=0 "${LIMA_CIDATA_DEV}" "${LIMA_CIDATA_MNT}"
-export LIMA_CIDATA_MNT
 
 . "${LIMA_CIDATA_MNT}"/lima.env
 
@@ -77,5 +81,3 @@ DNS=$(awk '/nameservers:/{flag=1; next} /^[^ ]/{flag=0} flag {gsub("^ +- +", "")
 if [ -n "${DNS}" ]; then
     sed -i "/export dns/a dns=\"${DNS}\"" /usr/share/udhcpc/default.script
 fi
-
-exec "${LIMA_CIDATA_MNT}"/boot.sh


### PR DESCRIPTION
lima-init-local runs before the network is up (so links can be modified without bringing them down and back up again). lima-init runs once the network is up, so boot scripts can install additional packages.

This mirrors how cloud-init is split into several services.
