### PR TITLE
Enable PAM support for sshd

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,7 @@ docker run -it --rm \
        -v "${PWD}/lima-init-local.openrc:/home/build/lima-init-local.openrc:ro" \
        -v "${PWD}/lima-network.awk:/home/build/lima-network.awk:ro" \
        -v "${PWD}/nerdctl-${NERDCTL_VERSION}:/home/build/nerdctl.tar.gz:ro" \
+       -v "${PWD}/sshd.pam:/home/build/sshd.pam:ro" \
        $(env | grep ^LIMA_ | xargs -n 1 printf -- '-e %s ') \
        -e "LIMA_REPO_VERSION=${REPO_VERSION}" \
        "mkimage:${ALPINE_VERSION}" \

--- a/genapkovl-lima.sh
+++ b/genapkovl-lima.sh
@@ -44,7 +44,7 @@ EOF
 mkdir -p "$tmp"/etc/apk
 makefile root:root 0644 "$tmp"/etc/apk/world <<EOF
 alpine-base
-openssh
+openssh-server-pam
 EOF
 
 rc_add devfs sysinit
@@ -72,6 +72,17 @@ rc_add savecache shutdown
 rc_add networking default
 
 rc_add sshd default
+
+rc_add local default
+
+mkdir -p "${tmp}/etc/local.d/"
+makefile root:root 0755 "$tmp/etc/local.d/lima.start" << EOF
+sed -i 's/#UsePAM no/UsePAM yes/g' /etc/ssh/sshd_config
+rc-service --ifstarted sshd reload
+EOF
+
+mkdir -p "$tmp"/etc/pam.d
+cp /home/build/sshd.pam "${tmp}/etc/pam.d/sshd"
 
 if [ "${LIMA_INSTALL_LIMA_INIT}" == "true" ]; then
     rc_add lima-init default

--- a/mkimg.lima.sh
+++ b/mkimg.lima.sh
@@ -13,7 +13,7 @@ profile_lima() {
 	kernel_cmdline="console=tty0 console=ttyS0,115200"
 	syslinux_serial="0 115200"
 	apkovl="genapkovl-lima.sh"
-	apks="$apks openssh"
+	apks="$apks openssh-server-pam"
         if [ "${LIMA_INSTALL_CA_CERTIFICATES}" == "true" ]; then
             apks="$apks ca-certificates"
         fi

--- a/sshd.pam
+++ b/sshd.pam
@@ -1,0 +1,4 @@
+auth      include   system-login
+account   include   system-login
+password  include   system-login
+session   include   system-login


### PR DESCRIPTION
Requires a special build with pam compiled in. Using the `system-login` pam configuration as Alpine doesn't have `system-remote-login`.

Main motivation is getting support for `/etc/environment` in ssh sessions.
