### PR TITLE
Add `BUILD_ID` and `VARIANT_ID` to `/etc/os-release`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 ALPINE_VERSION ?= 3.13.5
 REPO_VERSION ?= $(shell echo "$(ALPINE_VERSION)" | sed -E 's/^([0-9]+\.[0-9]+).*/v\1/')
 GIT_TAG ?= $(shell echo "v$(ALPINE_VERSION)" | sed 's/^vedge$$/origin\/master/')
+BUILD_ID ?= $(shell git describe --tags)
 
 # Editions should be 5 chars or less because the full name is used as
 # the volume id, and cannot exceed 32 characters.
@@ -19,7 +20,7 @@ mkimage:
 
 .PHONY: iso
 iso: nerdctl-$(NERDCTL_VERSION)
-	ALPINE_VERSION=$(ALPINE_VERSION) NERDCTL_VERSION=$(NERDCTL_VERSION) REPO_VERSION=$(REPO_VERSION) EDITION=$(EDITION) ./build.sh
+	ALPINE_VERSION=$(ALPINE_VERSION) NERDCTL_VERSION=$(NERDCTL_VERSION) REPO_VERSION=$(REPO_VERSION) EDITION=$(EDITION) BUILD_ID=$(BUILD_ID) ./build.sh
 
 nerdctl-$(NERDCTL_VERSION):
 	curl -o $@ -Ls https://github.com/containerd/nerdctl/releases/download/v$(NERDCTL_VERSION)/nerdctl-full-$(NERDCTL_VERSION)-linux-amd64.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILD_ID ?= $(shell git describe --tags)
 # len("alpine-lima-12345-3.13.5-x86_64") == 31
 EDITION ?= std
 
-NERDCTL_VERSION=0.11.1
+NERDCTL_VERSION=0.12.1
 
 .PHONY: mkimage
 mkimage:

--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,8 @@ docker run -it --rm \
        -v "${PWD}/sshd.pam:/home/build/sshd.pam:ro" \
        $(env | grep ^LIMA_ | xargs -n 1 printf -- '-e %s ') \
        -e "LIMA_REPO_VERSION=${REPO_VERSION}" \
+       -e "LIMA_BUILD_ID=${BUILD_ID}" \
+       -e "LIMA_VARIANT_ID=${EDITION}" \
        "mkimage:${ALPINE_VERSION}" \
        --tag "${TAG}" \
        --outdir /iso \

--- a/genapkovl-lima.sh
+++ b/genapkovl-lima.sh
@@ -79,6 +79,11 @@ mkdir -p "${tmp}/etc/local.d/"
 makefile root:root 0755 "$tmp/etc/local.d/lima.start" << EOF
 sed -i 's/#UsePAM no/UsePAM yes/g' /etc/ssh/sshd_config
 rc-service --ifstarted sshd reload
+
+if ! grep -q BUILD_ID /etc/os-release; then
+    echo "BUILD_ID=\"${LIMA_BUILD_ID}\"" >> /etc/os-release
+    echo "VARIANT_ID=\"${LIMA_VARIANT_ID}\"" >> /etc/os-release
+fi
 EOF
 
 mkdir -p "$tmp"/etc/pam.d


### PR DESCRIPTION
`BUILD_ID` is the `git describe --tags` value, and `VARIANT_ID` is the name of the edition, e.g. "std".

Also bump `nerdctl` to the latest release (0.12.1).