### PR TITLE
Add arm64/aarch64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 ARG ALPINE_VERSION=latest
 FROM alpine:${ALPINE_VERSION}
 RUN apk add alpine-sdk build-base apk-tools alpine-conf busybox \
-  fakeroot syslinux xorriso squashfs-tools sudo \
+  fakeroot xorriso squashfs-tools sudo \
   mtools dosfstools grub-efi
+
+# syslinux is missing for aarch64
+ARG TARGETARCH
+RUN if [ "${TARGETARCH}" = "amd64" ]; then apk add syslinux; fi
+
 RUN adduser -h /home/build -D build -G abuild
 RUN echo "%abuild ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/abuild
 ADD src/aports /home/build/aports

--- a/Makefile
+++ b/Makefile
@@ -8,32 +8,43 @@ BUILD_ID ?= $(shell git describe --tags)
 # len("alpine-lima-12345-3.13.5-x86_64") == 31
 EDITION ?= std
 
+# Architecture defaults to the current system's.
+ARCH ?= $(shell uname -m)
+
+# ARCH is derived from `uname -m` but the alternate architecture name (e.g. amd64, arm64)
+# is required for Docker and asset downloads.
+ARCH_ALIAS_x86_64 = amd64
+ARCH_ALIAS_aarch64 = arm64
+ARCH_ALIAS = $(shell echo "$(ARCH_ALIAS_$(ARCH))")
+
 NERDCTL_VERSION=0.12.1
 
 .PHONY: mkimage
 mkimage:
 	cd src/aports && git fetch && git checkout $(GIT_TAG)
 	docker build \
-		--tag mkimage:$(ALPINE_VERSION) \
+		--tag mkimage:$(ALPINE_VERSION)-$(ARCH) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
+		--platform linux/$(ARCH_ALIAS) \
 		.
 
 .PHONY: iso
-iso: nerdctl-$(NERDCTL_VERSION)
-	ALPINE_VERSION=$(ALPINE_VERSION) NERDCTL_VERSION=$(NERDCTL_VERSION) REPO_VERSION=$(REPO_VERSION) EDITION=$(EDITION) BUILD_ID=$(BUILD_ID) ./build.sh
+iso: nerdctl-$(NERDCTL_VERSION)-$(ARCH)
+	ALPINE_VERSION=$(ALPINE_VERSION) NERDCTL_VERSION=$(NERDCTL_VERSION) REPO_VERSION=$(REPO_VERSION) EDITION=$(EDITION) BUILD_ID=$(BUILD_ID) ARCH=$(ARCH) ARCH_ALIAS=$(ARCH_ALIAS) ./build.sh
 
-nerdctl-$(NERDCTL_VERSION):
-	curl -o $@ -Ls https://github.com/containerd/nerdctl/releases/download/v$(NERDCTL_VERSION)/nerdctl-full-$(NERDCTL_VERSION)-linux-amd64.tar.gz
+
+nerdctl-$(NERDCTL_VERSION)-$(ARCH):
+	curl -o $@ -Ls https://github.com/containerd/nerdctl/releases/download/v$(NERDCTL_VERSION)/nerdctl-full-$(NERDCTL_VERSION)-linux-$(ARCH_ALIAS).tar.gz
 
 .PHONY: lima
 lima:
-	ALPINE_VERSION=$(ALPINE_VERSION) EDITION=$(EDITION) ./lima.sh
+	ALPINE_VERSION=$(ALPINE_VERSION) EDITION=$(EDITION) ARCH=$(ARCH) ./lima.sh
 
 .PHONY: run
 run:
-	qemu-system-x86_64 \
+	qemu-system-$(ARCH) \
 		-boot order=d,splash-time=0,menu=on \
-		-cdrom iso/alpine-lima-$(EDITION)-$(ALPINE_VERSION)-x86_64.iso \
+		-cdrom iso/alpine-lima-$(EDITION)-$(ALPINE_VERSION)-$(ARCH).iso \
 		-cpu host \
 		-machine q35,accel=hvf \
 		-smp 4,sockets=1,cores=4,threads=1 \

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ The "k3s" edition is the same as "ci" plus `k3s` pre-installed. This is still su
 
 The "rd" edition includes additional components for Rancher Desktop. These can change randomly to match particular RD releases (or just experiments) and should not be relied on by other applications.
 
+## Architecture
+
+This repo supports the generation of images for different architectures. 
+Only `x86_64` and `aarch64` have been tested but other architectures can also be generated.
+
 ## Building and testing
 
 Note that this repo includes the [Alpine aports](https://github.com/alpinelinux/aports.git) repository as a submodule. If you didn't specify the `--recursive` option when cloning this repo, then you need to initialize the submodule by running:
@@ -46,7 +51,8 @@ Note that this repo includes the [Alpine aports](https://github.com/alpinelinux/
 git submodule update --init
 ```
 
-The examples show the default values for `ALPINE_VERSION=3.13.5 EDITION=std`. The options need to be specified only to select non-default setting.
+The examples show the default values for `ALPINE_VERSION=3.13.5 EDITION=std`, `ARCH` defaults to the OS architecture `uname -m`.
+The options need to be specified only to select non-default setting.
 
 ### Build the builder
 

--- a/build.sh
+++ b/build.sh
@@ -8,23 +8,24 @@ TAG="${EDITION}-${ALPINE_VERSION}"
 source "edition/${EDITION}"
 
 docker run -it --rm \
-       -v "${PWD}/iso:/iso" \
-       -v "${PWD}/mkimg.lima.sh:/home/build/aports/scripts/mkimg.lima.sh:ro" \
-       -v "${PWD}/genapkovl-lima.sh:/home/build/aports/scripts/genapkovl-lima.sh:ro" \
-       -v "${PWD}/lima-init.sh:/home/build/lima-init.sh:ro" \
-       -v "${PWD}/lima-init.openrc:/home/build/lima-init.openrc:ro" \
-       -v "${PWD}/lima-init-local.openrc:/home/build/lima-init-local.openrc:ro" \
-       -v "${PWD}/lima-network.awk:/home/build/lima-network.awk:ro" \
-       -v "${PWD}/nerdctl-${NERDCTL_VERSION}:/home/build/nerdctl.tar.gz:ro" \
-       -v "${PWD}/sshd.pam:/home/build/sshd.pam:ro" \
-       $(env | grep ^LIMA_ | xargs -n 1 printf -- '-e %s ') \
-       -e "LIMA_REPO_VERSION=${REPO_VERSION}" \
-       -e "LIMA_BUILD_ID=${BUILD_ID}" \
-       -e "LIMA_VARIANT_ID=${EDITION}" \
-       "mkimage:${ALPINE_VERSION}" \
-       --tag "${TAG}" \
-       --outdir /iso \
-       --arch x86_64 \
-       --repository "http://dl-cdn.alpinelinux.org/alpine/${REPO_VERSION}/main" \
-       --repository "http://dl-cdn.alpinelinux.org/alpine/${REPO_VERSION}/community" \
-       --profile lima
+    --platform "linux/${ARCH_ALIAS}" \
+    -v "${PWD}/iso:/iso" \
+    -v "${PWD}/mkimg.lima.sh:/home/build/aports/scripts/mkimg.lima.sh:ro" \
+    -v "${PWD}/genapkovl-lima.sh:/home/build/aports/scripts/genapkovl-lima.sh:ro" \
+    -v "${PWD}/lima-init.sh:/home/build/lima-init.sh:ro" \
+    -v "${PWD}/lima-init.openrc:/home/build/lima-init.openrc:ro" \
+    -v "${PWD}/lima-init-local.openrc:/home/build/lima-init-local.openrc:ro" \
+    -v "${PWD}/lima-network.awk:/home/build/lima-network.awk:ro" \
+    -v "${PWD}/nerdctl-${NERDCTL_VERSION}-${ARCH}:/home/build/nerdctl.tar.gz:ro" \
+    -v "${PWD}/sshd.pam:/home/build/sshd.pam:ro" \
+    $(env | grep ^LIMA_ | xargs -n 1 printf -- '-e %s ') \
+    -e "LIMA_REPO_VERSION=${REPO_VERSION}" \
+    -e "LIMA_BUILD_ID=${BUILD_ID}" \
+    -e "LIMA_VARIANT_ID=${EDITION}" \
+    "mkimage:${ALPINE_VERSION}-${ARCH}" \
+    --tag "${TAG}" \
+    --outdir /iso \
+    --arch "${ARCH}" \
+    --repository "http://dl-cdn.alpinelinux.org/alpine/${REPO_VERSION}/main" \
+    --repository "http://dl-cdn.alpinelinux.org/alpine/${REPO_VERSION}/community" \
+    --profile lima

--- a/lima.sh
+++ b/lima.sh
@@ -2,9 +2,10 @@
 set -eu
 
 cat <<EOF >"${EDITION}.yaml"
+arch: "${ARCH}"
 images:
-- location: "${PWD}/iso/alpine-lima-${EDITION}-${ALPINE_VERSION}-x86_64.iso"
-  arch: "x86_64"
+- location: "${PWD}/iso/alpine-lima-${EDITION}-${ALPINE_VERSION}-${ARCH}.iso"
+  arch: "${ARCH}"
 mounts:
 - location: "~"
   writable: false


### PR DESCRIPTION
Fixes https://github.com/lima-vm/alpine-lima/issues/26.

This introduces an additional `ARCH` value that defaults to the output of `uname -m`. e.g. `x86_64`, `aarch64`.

~I contemplated accepting `aarch64` as value instead  of `arm64` but it requires more code changes. I opted for the easier way out.~