### PR TITLE
Add podman edition of alpine-lima

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ The "std" edition uses a custom "lima-init" script instead of "cloud-init" to av
 
 Right now the "std" edition also installs `qemu-aarch64` and configures it via `binfmt_misc` to be able to run Apple Silicon binaries. This is not the whole `qemu-openrc` package, but just the minimal subset for this one architecture, plus the configuration script.
 
+### Podman: pm
+
+The "pm" edition is the same as "std" plus `podman` pre-installed, by default without daemons.
+
 ### Kubernetes: k3s
 
 The "k3s" edition is the same as "ci" plus `k3s` pre-installed. This is still subject to change.

--- a/edition/min
+++ b/edition/min
@@ -7,4 +7,5 @@ export LIMA_INSTALL_IPTABLES=false
 export LIMA_INSTALL_LIMA_INIT=false
 export LIMA_INSTALL_LOGROTATE=false
 export LIMA_INSTALL_NERDCTL=false
+export LIMA_INSTALL_PODMAN=false
 export LIMA_INSTALL_SSHFS=false

--- a/edition/pm
+++ b/edition/pm
@@ -1,0 +1,2 @@
+source edition/std
+LIMA_INSTALL_PODMAN=true

--- a/genapkovl-lima.sh
+++ b/genapkovl-lima.sh
@@ -163,6 +163,14 @@ if [ "${LIMA_INSTALL_DOCKER}" == "true" ]; then
     echo socat >> "$tmp"/etc/apk/world
 fi
 
+if [ "${LIMA_INSTALL_PODMAN}" == "true" ]; then
+    echo crun >> "$tmp"/etc/apk/world # "runc"
+    echo conmon >> "$tmp"/etc/apk/world # "containerd"
+    echo catatonit >> "$tmp"/etc/apk/world # "tini"
+    echo cni-plugins >> "$tmp"/etc/apk/world
+    echo podman >> "$tmp"/etc/apk/world
+fi
+
 if [ "${LIMA_INSTALL_BINFMT_MISC}" == "true" ]; then
     # install qemu-aarch64 on x86_64 and vice versa
     OTHERARCH=aarch64

--- a/mkimg.lima.sh
+++ b/mkimg.lima.sh
@@ -25,6 +25,9 @@ profile_lima() {
             apks="$apks docker-engine docker-openrc docker-cli docker"
             apks="$apks socat"
         fi
+        if [ "${LIMA_INSTALL_PODMAN}" == "true" ]; then
+            apks="$apks crun conmon catatonit cni-plugins podman"
+        fi
         if [ "${LIMA_INSTALL_LIMA_INIT}" == "true" ]; then
             apks="$apks e2fsprogs lsblk sfdisk shadow sudo udev"
         fi


### PR DESCRIPTION
Make a "pm" edition for completeness:

```
LIMA_INSTALL_DOCKER=false

LIMA_INSTALL_PODMAN=true

LIMA_INSTALL_NERDCTL=false
LIMA_INSTALL_CONTAINERD=false
LIMA_INSTALL_BUILDKIT=false
```

Basically it is with: `apk add podman`

Allows running podman, but does not start "podman.sock".

You can still run and build, without running the daemons.

Closes #43