### PR TITLE
Add socat to docker installs

### DIFF
--- a/genapkovl-lima.sh
+++ b/genapkovl-lima.sh
@@ -158,6 +158,9 @@ if [ "${LIMA_INSTALL_DOCKER}" == "true" ]; then
     echo docker-openrc >> "$tmp"/etc/apk/world
     echo docker-cli >> "$tmp"/etc/apk/world
     echo docker >> "$tmp"/etc/apk/world
+
+    # kubectl port-forward requires `socat` when using docker-shim
+    echo socat >> "$tmp"/etc/apk/world
 fi
 
 if [ "${LIMA_INSTALL_BINFMT_MISC}" == "true" ]; then

--- a/mkimg.lima.sh
+++ b/mkimg.lima.sh
@@ -23,6 +23,7 @@ profile_lima() {
         if [ "${LIMA_INSTALL_DOCKER}" == "true" ]; then
             apks="$apks libseccomp runc containerd tini-static device-mapper-libs"
             apks="$apks docker-engine docker-openrc docker-cli docker"
+            apks="$apks socat"
         fi
         if [ "${LIMA_INSTALL_LIMA_INIT}" == "true" ]; then
             apks="$apks e2fsprogs lsblk sfdisk shadow sudo udev"


### PR DESCRIPTION
Because kubectl port-forward needs it when using docker-shim.
