### PR TITLE
Add docker edition of alpine-lima

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ The "std" edition uses a custom "lima-init" script instead of "cloud-init" to av
 
 Right now the "std" edition also installs `qemu-aarch64` and configures it via `binfmt_misc` to be able to run Apple Silicon binaries. This is not the whole `qemu-openrc` package, but just the minimal subset for this one architecture, plus the configuration script.
 
+### Docker: de
+
+The "de" edition is the same as "std" plus `docker` pre-installed, that is: Docker Engine.
+
 ### Kubernetes: k3s
 
 The "k3s" edition is the same as "ci" plus `k3s` pre-installed. This is still subject to change.

--- a/edition/de
+++ b/edition/de
@@ -1,0 +1,2 @@
+source edition/std
+LIMA_INSTALL_DOCKER=true


### PR DESCRIPTION
It seems like currently it doesn't start the daemon by default ?

```
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

And the user is not automagically added to the "docker" group.

`Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.24/version": dial unix /var/run/docker.sock: connect: permission denied`

----

But that is "normal", I guess. After starting and running as root, it works:

```
lima-de:/home/anders/alpine-lima$ sudo /etc/init.d/docker start
 * /var/log/docker.log: creating file
 * /var/log/docker.log: correcting owner
 * Starting Docker Daemon ...                                                                                                                                                                        [ ok ]
lima-de:/home/anders/alpine-lima$ sudo docker version
Client:
 Version:           20.10.11
 API version:       1.41
 Go version:        go1.16.10
 Git commit:        dea9396e184290f638ea873c76db7c80efd5a1d2
 Built:             Fri Nov 19 03:42:54 2021
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true

Server:
 Engine:
  Version:          20.10.11
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.16.10
  Git commit:       847da184ad5048b27f5bdf9d53d070f731b43180
  Built:            Fri Nov 19 03:41:34 2021
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          v1.5.8
  GitCommit:        1e5ef943eb76627a6d3b6de8cd1ef6537f393a71
 runc:
  Version:          1.0.0-rc95
  GitCommit:        b9ee9c6314599f1b4a7f497e1f1f856fe433d3b7
 docker-init:
  Version:          0.19.0
  GitCommit:        
```

The main difference from standard docker is newer containerd (older runc).

https://download.docker.com/linux/static/stable/x86_64/docker-20.10.11.tgz

* Docker version 20.10.11, build 847da18
* containerd github.com/containerd/containerd v1.4.12 7b11cfaabd73bb80907dd23182b9347b4245eb5d
* runc version 1.0.2, commit: v1.0.2-0-g52b36a2d

Closes #45