### PR TITLE
Fix running on ARM Macs and support nerdctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ EDITION ?= std
 
 # Architecture defaults to the current system's.
 ARCH ?= $(shell uname -m)
+ifeq ($(strip $(ARCH)),arm64)
+ARCH = aarch64
+endif
 
 # ARCH is derived from `uname -m` but the alternate architecture name (e.g. amd64, arm64)
 # is required for Docker and asset downloads.

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ ALPINE_VERSION ?= 3.14.3
 REPO_VERSION ?= $(shell echo "$(ALPINE_VERSION)" | sed -E 's/^([0-9]+\.[0-9]+).*/v\1/')
 GIT_TAG ?= $(shell echo "v$(ALPINE_VERSION)" | sed 's/^vedge$$/origin\/master/')
 BUILD_ID ?= $(shell git describe --tags)
+DOCKER ?= docker
 
 # Editions should be 5 chars or less because the full name is used as
 # the volume id, and cannot exceed 32 characters.
@@ -25,7 +26,7 @@ BINFMT_IMAGE=tonistiigi/binfmt:qemu-$(QEMU_VERSION)
 .PHONY: mkimage
 mkimage:
 	cd src/aports && git fetch && git checkout $(GIT_TAG)
-	docker build \
+	$(DOCKER) build \
 		--tag mkimage:$(ALPINE_VERSION)-$(ARCH) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
 		--build-arg BINFMT_IMAGE=$(BINFMT_IMAGE) \

--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 set -eu
 
+DOCKER=${DOCKER:-docker}
+
 mkdir -p iso
 
 TAG="${EDITION}-${ALPINE_VERSION}"
 
 source "edition/${EDITION}"
 
-docker run --rm \
+${DOCKER} run --rm \
     --platform "linux/${ARCH_ALIAS}" \
     -v "${PWD}/iso:/iso" \
     -v "${PWD}/mkimg.lima.sh:/home/build/aports/scripts/mkimg.lima.sh:ro" \


### PR DESCRIPTION
- Support overriding docker command
- Makefile: Set ARCH to aarch64 when uname returns arm64
