### PR TITLE
Switch from Alpine 3.15.4 → 3.16.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 env:
-  ALPINE_VERSION: 3.15.4
+  ALPINE_VERSION: 3.16.0
   DOCKER_BUILDKIT: 1
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,14 +19,5 @@ RUN abuild-keygen -i -a -n
 RUN apk update
 
 ADD src/aports /home/build/aports
-
-RUN if [ "${TARGETARCH}" = "arm64" ]; then pkg_arch=aarch64; else pkg_arch=x86_64; fi && \
-   mkdir -p /home/build/packages/lima/${pkg_arch} && \
-   cd /home/build/packages/lima/${pkg_arch} && \
-   apk fetch cni-plugins --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community && \
-   apk fetch cni-plugin-flannel --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community && \
-   apk index -o APKINDEX.tar.gz *.apk && \
-   abuild-sign APKINDEX.tar.gz
-
 WORKDIR /home/build/aports/scripts
 ENTRYPOINT ["sh", "./mkimage.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ALPINE_VERSION ?= 3.15.4
+ALPINE_VERSION ?= 3.16.0
 REPO_VERSION ?= $(shell echo "$(ALPINE_VERSION)" | sed -E 's/^([0-9]+\.[0-9]+).*/v\1/')
 GIT_TAG ?= $(shell echo "v$(ALPINE_VERSION)" | sed 's/^vedge$$/origin\/master/')
 BUILD_ID ?= $(shell git describe --tags)


### PR DESCRIPTION
This gives us an updated containerd package, and we no longer need to install the cni-* packages from the edge repo. This reverts part of e264e7b0b.

https://github.com/lima-vm/lima/pull/891 must be merged before Lima supports Alpine 3.16.

Fixes #66
