### PR TITLE
qemu-binfmt: Enable perserve-argv.

### DIFF
--- a/genapkovl-lima.sh
+++ b/genapkovl-lima.sh
@@ -195,6 +195,9 @@ if [ "${LIMA_INSTALL_BINFMT_MISC}" == "true" ]; then
     arch="x86_64"
     sed -i "/^FMTS=/a \\\t${magic} ${mask} ${arch}" "${tmp}/etc/init.d/qemu-binfmt"
 
+    # qemu from tonistiigi/binfmt is patched to assume preserve-argv; set it here.
+    echo 'binfmt_flags="POCF"' > "${tmp}/etc/conf.d/qemu-binfmt"
+
     rc_add qemu-binfmt default
 fi
 

--- a/genapkovl-lima.sh
+++ b/genapkovl-lima.sh
@@ -196,6 +196,7 @@ if [ "${LIMA_INSTALL_BINFMT_MISC}" == "true" ]; then
     sed -i "/^FMTS=/a \\\t${magic} ${mask} ${arch}" "${tmp}/etc/init.d/qemu-binfmt"
 
     # qemu from tonistiigi/binfmt is patched to assume preserve-argv; set it here.
+    mkdir -p "${tmp}/etc/conf.d"
     echo 'binfmt_flags="POCF"' > "${tmp}/etc/conf.d/qemu-binfmt"
 
     rc_add qemu-binfmt default


### PR DESCRIPTION
We get our qemu binaries from the tonistiigi/binfmt docker image; as of [commit `c5e21394`](https://github.com/tonistiigi/binfmt/commit/c5e21394c9378124b17cdf9c4a1c09b119cfba17) it has been patched to assume perserve-argv if no flags are set.  Explicitly set that flag so that argument parsing works correctly for binaries executed through qemu (via `binfmt_misc`).

Fixes: #81
