### PR TITLE
flannel symlink is no longer needed

### DIFF
--- a/genapkovl-lima.sh
+++ b/genapkovl-lima.sh
@@ -221,8 +221,6 @@ if [ "${LIMA_INSTALL_CNI_PLUGIN_FLANNEL}" == "true" ]; then
     if [ "$(uname -m)" == "aarch64" ]; then
         ARCH=arm64
     fi
-    mkdir -p "${tmp}/usr/libexec/cni"
-    ln -s "flannel-${ARCH}" "${tmp}/usr/libexec/cni/flannel"
 fi
 
 if [ "${LIMA_INSTALL_CURL}" == "true" ]; then


### PR DESCRIPTION
The cni-plugin-flannel package has fixed the filename in https://gitlab.alpinelinux.org/alpine/aports/-/commit/3c538f8ebbabad58615ea6d2eac4abbee3a02555

So the symlink will get overridden anyways, as soon as the package is installed.
