### PR TITLE
Create `/proc/sys/fs/binfmt_misc` and setup `/etc/init.d/procfs`

### DIFF
--- a/genapkovl-lima.sh
+++ b/genapkovl-lima.sh
@@ -171,6 +171,12 @@ if [ "${LIMA_INSTALL_DOCKER}" == "true" ]; then
     echo xz >> "$tmp"/etc/apk/world
 fi
 
+# /proc/sys/fs/binfmt_misc must exist for /etc/init.d/procfs to load
+# the binfmt-misc kernel module, which will then mount the filesystem.
+# This is needed for Rosetta to register.
+mkdir -p "${tmp}/proc/sys/fs/binfmt_misc"
+rc_add procfs default
+
 if [ "${LIMA_INSTALL_BINFMT_MISC}" == "true" ]; then
     # install qemu-aarch64 on x86_64 and vice versa
     OTHERARCH=aarch64
@@ -283,6 +289,7 @@ if [ "${LIMA_INSTALL_CRI_DOCKERD}" == "true" ]; then
 fi
 
 mkdir -p "${tmp}/etc"
+mkdir -p "${tmp}/proc"
 mkdir -p "${tmp}/usr"
 
-tar -c -C "$tmp" etc usr | gzip -9n > $HOSTNAME.apkovl.tar.gz
+tar -c -C "$tmp" etc proc usr | gzip -9n > $HOSTNAME.apkovl.tar.gz

--- a/lima-init.openrc
+++ b/lima-init.openrc
@@ -3,6 +3,7 @@
 depend() {
   after lima-init-local
   after net
+  after procfs
   provide lima-init
 }
 


### PR DESCRIPTION
Without this change the `binfmt_misc` filesystem isn't mounted and rosetta cannot be registered.

This isn't needed for `/etc/init.d/qemu-binfmt` because it loads the `binfmt-misc` kernel module itself if the filesystem isn't yet mounted.

Without this change (in `/var/log/lima-init.log`):

```
/mnt/lima-cidata/boot/05-rosetta-volume.sh: line 13: can't create /proc/sys/fs/binfmt_misc/register: nonexistent directory
```