### PR TITLE
Make sure lima-init runs after qemu-binfmt

### DIFF
--- a/lima-init.openrc
+++ b/lima-init.openrc
@@ -4,6 +4,7 @@ depend() {
   after lima-init-local
   after net
   after procfs
+  after qemu-binfmt
   provide lima-init
 }
 


### PR DESCRIPTION
That allows the boot scripts to disable qemu-static and enable rosetta instead.