### PR TITLE
Add ARCH=armv7l version of iso

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ TAG="${EDITION}-${ALPINE_VERSION}"
 source "edition/${EDITION}"
 
 ${DOCKER} run --rm \
-    --platform "linux/${ARCH_ALIAS}" \
+    --platform "linux/${DOCKER_ARCH}" \
     -v "${PWD}/iso:/iso" \
     -v "${PWD}/mkimg.lima.sh:/home/build/aports/scripts/mkimg.lima.sh:ro" \
     -v "${PWD}/genapkovl-lima.sh:/home/build/aports/scripts/genapkovl-lima.sh:ro" \
@@ -30,11 +30,11 @@ ${DOCKER} run --rm \
     "mkimage:${ALPINE_VERSION}-${ARCH}" \
     --tag "${TAG}" \
     --outdir /iso \
-    --arch "${ARCH}" \
+    --arch "${ALPINE_ARCH}" \
     --repository "/home/build/packages/lima" \
     --repository "http://dl-cdn.alpinelinux.org/alpine/${REPO_VERSION}/main" \
     --repository "http://dl-cdn.alpinelinux.org/alpine/${REPO_VERSION}/community" \
     --profile lima
 
-ISO="alpine-lima-${EDITION}-${ALPINE_VERSION}-${ARCH}.iso"
+ISO="alpine-lima-${EDITION}-${ALPINE_VERSION}-${ALPINE_ARCH}.iso"
 cd iso && sha512sum "${ISO}" > "${ISO}.sha512sum"

--- a/genapkovl-lima.sh
+++ b/genapkovl-lima.sh
@@ -177,10 +177,12 @@ fi
 mkdir -p "${tmp}/proc/sys/fs/binfmt_misc"
 rc_add procfs default
 
-if [ "${LIMA_INSTALL_BINFMT_MISC}" == "true" ]; then
+if [ "${LIMA_INSTALL_BINFMT_MISC}" == "true" ] && [ "$(uname -m)" != "armv7l" ]; then
     # install qemu-aarch64 on x86_64 and vice versa
-    OTHERARCH=aarch64
-    if [ "$(uname -m)" == "${OTHERARCH}" ]; then
+    if [ "$(uname -m)" == "x86_64" ]; then
+        OTHERARCH=aarch64
+    fi
+    if [ "$(uname -m)" == "aarch64" ]; then
         OTHERARCH=x86_64
     fi
 
@@ -223,9 +225,14 @@ fi
 
 if [ "${LIMA_INSTALL_CNI_PLUGIN_FLANNEL}" == "true" ]; then
     echo "cni-plugin-flannel" >> "$tmp"/etc/apk/world
-    ARCH=amd64
+    if [ "$(uname -m)" == "x86_64" ]; then
+        ARCH=amd64
+    fi
     if [ "$(uname -m)" == "aarch64" ]; then
         ARCH=arm64
+    fi
+    if [ "$(uname -m)" == "armv7l" ]; then
+        ARCH=armv7
     fi
 fi
 

--- a/lima.sh
+++ b/lima.sh
@@ -5,6 +5,10 @@ case "$(uname)" in
   Darwin) display=cocoa;;
   Linux) display=gtk;;
 esac
+case "${ARCH}" in
+  x86_64) bios=true;;
+  *) bios=false;;
+esac
 cat <<EOF >"${EDITION}.yaml"
 arch: "${ARCH}"
 images:
@@ -18,7 +22,7 @@ mounts:
 ssh:
   localPort: 40022
 firmware:
-  legacyBIOS: true
+  legacyBIOS: $bios
 video:
   display: $display
 containerd:

--- a/lima.sh
+++ b/lima.sh
@@ -8,7 +8,7 @@ esac
 cat <<EOF >"${EDITION}.yaml"
 arch: "${ARCH}"
 images:
-- location: "${PWD}/iso/alpine-lima-${EDITION}-${ALPINE_VERSION}-${ARCH}.iso"
+- location: "${PWD}/iso/alpine-lima-${EDITION}-${ALPINE_VERSION}-${ALPINE_ARCH}.iso"
   arch: "${ARCH}"
 mounts:
 - location: "~"

--- a/mkimg.lima.sh
+++ b/mkimg.lima.sh
@@ -6,7 +6,7 @@ profile_lima() {
 		Slimmed down kernel.
 		Optimized for virtual systems.
 		Configured for lima."
-	arch="aarch64 x86 x86_64"
+	arch="aarch64 armv7 x86 x86_64"
 	initfs_cmdline="modules=loop,squashfs,sd-mod,usb-storage"
 	kernel_addons=
 	kernel_flavors="virt"

--- a/mkimg.lima.sh
+++ b/mkimg.lima.sh
@@ -10,7 +10,11 @@ profile_lima() {
 	initfs_cmdline="modules=loop,squashfs,sd-mod,usb-storage"
 	kernel_addons=
 	kernel_flavors="virt"
-	kernel_cmdline="console=tty0 console=ttyS0,115200"
+	case "$ARCH" in
+		arm*|aarch64)
+			kernel_cmdline="console=tty0 console=ttyAMA0"
+			;;
+	esac
 	syslinux_serial="0 115200"
 	apkovl="genapkovl-lima.sh"
 	apks="$apks openssh-server-pam"


### PR DESCRIPTION

The Ubuntu image for armv7 is over 1G, so make a smaller image for emulation.

It is slow, but it boots.

```
Welcome to Alpine Linux 3.18
Kernel 6.1.34-3-virt on an armv7l (/dev/ttyAMA0)
```

Not every dependency, such as nerdctl-full, is available for arm-v7. But most are...