### PR TITLE
fix(mkimage): log console messages to hvc0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,6 @@ ${DOCKER} run --rm \
     --tag "${TAG}" \
     --outdir /iso \
     --arch "${ARCH}" \
-    --repository "/home/build/packages/lima" \
     --repository "http://dl-cdn.alpinelinux.org/alpine/${REPO_VERSION}/main" \
     --repository "http://dl-cdn.alpinelinux.org/alpine/${REPO_VERSION}/community" \
     --profile lima

--- a/lima.sh
+++ b/lima.sh
@@ -17,8 +17,6 @@ mounts:
   writable: true
 ssh:
   localPort: 40022
-firmware:
-  legacyBIOS: true
 video:
   display: $display
 containerd:

--- a/mkimg.lima.sh
+++ b/mkimg.lima.sh
@@ -10,7 +10,7 @@ profile_lima() {
 	initfs_cmdline="modules=loop,squashfs,sd-mod,usb-storage"
 	kernel_addons=
 	kernel_flavors="virt"
-	kernel_cmdline="console=tty0 console=ttyS0,115200"
+	kernel_cmdline="console=hvc0 console=tty0 console=ttyS0,115200"
 	syslinux_serial="0 115200"
 	apkovl="genapkovl-lima.sh"
 	apks="$apks openssh-server-pam"


### PR DESCRIPTION
VZ has support for serial console logging but the device is different from Qemu. VZ uses the hypervisor virtual console device instead. This change modifies the bootloader to add hvc0 as a device to log console messages to on boot. Also added some changes that removes some settings/configs that are not needed anymore.

Issue: https://github.com/lima-vm/lima/issues/1659