### PR TITLE
We need tini-static for `nerdctl run --init`

### DIFF
--- a/genapkovl-lima.sh
+++ b/genapkovl-lima.sh
@@ -278,7 +278,8 @@ if [ "${LIMA_INSTALL_ZSTD}" == "true" ]; then
 fi
 
 if [ "${LIMA_INSTALL_TINI}" == "true" ]; then
-    echo "tini" >> "$tmp"/etc/apk/world
+    echo tini-static >> "$tmp"/etc/apk/world
+    ln -sf /sbin/tini-static "$tmp"/usr/bin/tini
 fi
 
 if [ "${LIMA_INSTALL_CRI_DOCKERD}" == "true" ]; then

--- a/mkimg.lima.sh
+++ b/mkimg.lima.sh
@@ -59,7 +59,7 @@ profile_lima() {
             apks="$apks sshfs"
         fi
         if [ "${LIMA_INSTALL_TINI}" == "true" ]; then
-            apks="$apks tini"
+            apks="$apks tini-static"
         fi
         if [ "${LIMA_INSTALL_IPTABLES}" == "true" ] || [ "${LIMA_INSTALL_NERDCTL_FULL}" == "true" ]; then
             apks="$apks iptables ip6tables"


### PR DESCRIPTION
The regular `tini` binary is linked against musl, so won't work in non-Alpine containers.

```console
lima-std:~# ldd /sbin/tini
	/lib/ld-musl-x86_64.so.1 (0x7f32fea7c000)
	libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x7f32fea7c000)
```