### PR TITLE
fix(mkimage): log console boot messages to hvc0

### DIFF
--- a/mkimg.lima.sh
+++ b/mkimg.lima.sh
@@ -10,7 +10,7 @@ profile_lima() {
 	initfs_cmdline="modules=loop,squashfs,sd-mod,usb-storage"
 	kernel_addons=
 	kernel_flavors="virt"
-	kernel_cmdline="console=tty0 console=ttyS0,115200"
+	kernel_cmdline="console=hvc0 console=tty0 console=ttyS0,115200"
 	syslinux_serial="0 115200"
 	apkovl="genapkovl-lima.sh"
 	apks="$apks openssh-server-pam"


### PR DESCRIPTION
VZ has support for serial console logging but the device is different from Qemu. VZ uses the hypervisor virtual console device instead. This change modifies the bootloader to add hvc0 as a device to log console messages to on boot.

Note this has no effect on the tty serial logging.

Issue: https://github.com/lima-vm/lima/issues/1659