### PR TITLE
Still need to install openssh-server-pam

### DIFF
--- a/genapkovl-lima.sh
+++ b/genapkovl-lima.sh
@@ -44,7 +44,7 @@ EOF
 mkdir -p "$tmp"/etc/apk
 makefile root:root 0644 "$tmp"/etc/apk/world <<EOF
 alpine-base
-openssh-server
+openssh-server-pam
 EOF
 
 rc_add devfs sysinit

--- a/mkimg.lima.sh
+++ b/mkimg.lima.sh
@@ -13,7 +13,7 @@ profile_lima() {
 	kernel_cmdline="console=hvc0 console=tty0 console=ttyS0,115200"
 	syslinux_serial="0 115200"
 	apkovl="genapkovl-lima.sh"
-	apks="$apks openssh-server"
+	apks="$apks openssh-server-pam"
         if [ "${LIMA_INSTALL_CA_CERTIFICATES}" == "true" ]; then
             apks="$apks ca-certificates"
         fi


### PR DESCRIPTION
While it now includes a proper `sshd.pam` file, it only gets installed by `openssh-server-pam` and not `openssh-server`.