### PR TITLE
Make sure the /etc/fstab is empty

### DIFF
--- a/genapkovl-lima.sh
+++ b/genapkovl-lima.sh
@@ -28,6 +28,10 @@ tmp="$(mktemp -d)"
 trap cleanup EXIT
 
 mkdir -p "$tmp"/etc
+makefile root:root 0644 "$tmp"/etc/fstab <<EOF
+# /etc/fstab
+EOF
+
 makefile root:root 0644 "$tmp"/etc/hostname <<EOF
 $HOSTNAME
 EOF


### PR DESCRIPTION
Otherwise we can get into a race condition between /media/cdrom and /media/sr0 both tryin to mount /dev/sr0.

See https://github.com/lima-vm/lima/pull/2143#issuecomment-1893062016. Hopefully this change will make that Lima PR redundant.