### PR TITLE
Look for ssh_authorized_keys without dashes

### DIFF
--- a/lima-init.sh
+++ b/lima-init.sh
@@ -128,7 +128,7 @@ fi
 LIMA_CA_CERTS=/usr/share/ca-certificates/lima-init-ca-certs.crt
 awk -f- "${LIMA_CIDATA_MNT}"/user-data <<'EOF' > ${LIMA_CA_CERTS}
 # Lima currently uses "ca-certs", which is deprecated and should be "ca_certs"
-/^ca.certs:/ {
+/^ca[-_]certs:/ {
     cacerts = 1
     next
 }

--- a/lima-init.sh
+++ b/lima-init.sh
@@ -39,7 +39,8 @@ echo "${LIMA_CIDATA_USER} ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/90-lima-users
 # Create authorized_keys
 LIMA_CIDATA_SSHDIR="${LIMA_CIDATA_HOMEDIR}"/.ssh
 mkdir -p -m 700 "${LIMA_CIDATA_SSHDIR}"
-awk '/ssh-authorized-keys/ {flag=1; next} /^ *$/ {flag=0} flag {sub(/^ +- /, ""); gsub(/^"|"$/,""); gsub("\\\\\"", "\""); print $0}' \
+# Lima currently uses "ssh-authorized-keys", which is invalid and should be "ssh_authorized_keys"
+awk '/ssh[-_]authorized[-_]keys/ {flag=1; next} /^ *$/ {flag=0} flag {sub(/^ +- /, ""); gsub(/^"|"$/,""); gsub("\\\\\"", "\""); print $0}' \
 	"${LIMA_CIDATA_MNT}"/user-data >"${LIMA_CIDATA_SSHDIR}"/authorized_keys
 LIMA_CIDATA_GID=$(id -g "${LIMA_CIDATA_USER}")
 chown -R "${LIMA_CIDATA_UID}:${LIMA_CIDATA_GID}" "${LIMA_CIDATA_SSHDIR}"


### PR DESCRIPTION
The documented spelling of ssh-authorized-keys is actually invalid according to jsonschema, even if accepted by python.

* https://github.com/lima-vm/lima/issues/2265

https://github.com/canonical/cloud-init/blob/main/cloudinit/config/schemas/schema-cloud-config-v1.json

```console
$ check-jsonschema --schemafile https://raw.githubusercontent.com/canonical/cloud-init/main/cloudinit/config/schemas/schema-cloud-config-v1.json --verbose cloud-config.yaml
...
    $.users[0]: Additional properties are not allowed ('ssh-authorized-keys' was unexpected)
```