### PR TITLE
Select tiny-cloud-nocloud package to provide tiny-cloud-alpine virtual package

### DIFF
--- a/mkimg.lima.sh
+++ b/mkimg.lima.sh
@@ -13,7 +13,7 @@ profile_lima() {
 	kernel_cmdline="console=hvc0 console=tty0 console=ttyS0,115200"
 	syslinux_serial="0 115200"
 	apkovl="genapkovl-lima.sh"
-	apks="$apks openssh-server-pam"
+	apks="$apks openssh-server-pam tiny-cloud-nocloud"
         if [ "${LIMA_INSTALL_CA_CERTIFICATES}" == "true" ]; then
             apks="$apks ca-certificates"
         fi


### PR DESCRIPTION
Building `make EDITION=std iso` today breaks with:

```
ERROR: unable to select packages:
  tiny-cloud-alpine (virtual):
    note: please select one of the 'provided by'
          packages explicitly
    provided by: tiny-cloud-nocloud
    required by: world[tiny-cloud-alpine]
  vlan-2.3-r1:
    breaks: ifupdown-ng-0.12.1-r5[!vlan]
    satisfies: network-extras-2.0-r0[vlan]
```

Probably due to https://gitlab.alpinelinux.org/alpine/aports/-/commit/f6ca45f2f8812537274b7b6e97b1eef85e20bd8d