### PR TITLE
Set explicit GITHUB_TOKEN permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,15 @@ env:
   ALPINE_VERSION: 3.23.0
   DOCKER_BUILDKIT: 1
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The workflow assumed the repository default granted contents: write. When that default is read-only (at repo or org level), `gh release create` fails with HTTP 403.

Declare contents: read at the workflow level and grant contents: write only to the release job, so the release no longer depends on the repository default.